### PR TITLE
Minor changes for bank integration props

### DIFF
--- a/app/Http/Controllers/Bank/YodleeController.php
+++ b/app/Http/Controllers/Bank/YodleeController.php
@@ -35,11 +35,11 @@ class YodleeController extends BaseController
 
         //ensure user is enterprise!!
 
-        if ($company->account->bank_integration_yodlee_account_id) {
+        if ($company->account->bank_integration_account_id) {
 
             $flow = 'edit';
 
-            $token = $company->account->bank_integration_yodlee_account_id;
+            $token = $company->account->bank_integration_account_id;
 
         } else {
 
@@ -49,7 +49,7 @@ class YodleeController extends BaseController
 
             $token = $response->user->loginName;
 
-            $company->account->bank_integration_yodlee_account_id = $token;
+            $company->account->bank_integration_account_id = $token;
 
             $company->push();
 

--- a/app/Http/Controllers/BankIntegrationController.php
+++ b/app/Http/Controllers/BankIntegrationController.php
@@ -553,10 +553,10 @@ class BankIntegrationController extends BaseController
     private function refreshAccountsYodlee(Account $account)
     {
 
-        if (!$account->bank_integration_yodlee_account_id)
+        if (!$account->bank_integration_account_id)
             return response()->json(['message' => 'Not yet authenticated with Bank Integration service'], 400);
 
-        $yodlee = new Yodlee($account->bank_integration_yodlee_account_id);
+        $yodlee = new Yodlee($account->bank_integration_account_id);
 
         $accounts = $yodlee->getAccounts();
 
@@ -673,10 +673,10 @@ class BankIntegrationController extends BaseController
 
     private function removeAccountYodlee(Account $account, BankIntegration $bank_integration)
     {
-        if (!$account->bank_integration_yodlee_account_id)
+        if (!$account->bank_integration_account_id)
             return response()->json(['message' => 'Not yet authenticated with Bank Integration service'], 400);
 
-        $yodlee = new Yodlee($account->bank_integration_yodlee_account_id);
+        $yodlee = new Yodlee($account->bank_integration_account_id);
         $yodlee->deleteAccount($bank_integration->bank_account_id);
     }
 

--- a/app/Jobs/Bank/MatchBankTransactions.php
+++ b/app/Jobs/Bank/MatchBankTransactions.php
@@ -94,8 +94,8 @@ class MatchBankTransactions implements ShouldQueue
 
         $this->company = Company::find($this->company_id);
 
-        if ($this->company->account->bank_integration_yodlee_account_id)
-            $yodlee = new Yodlee($this->company->account->bank_integration_yodlee_account_id);
+        if ($this->company->account->bank_integration_account_id)
+            $yodlee = new Yodlee($this->company->account->bank_integration_account_id);
         else
             $yodlee = false;
 

--- a/app/Jobs/Bank/ProcessBankTransactionsYodlee.php
+++ b/app/Jobs/Bank/ProcessBankTransactionsYodlee.php
@@ -76,7 +76,7 @@ class ProcessBankTransactionsYodlee implements ShouldQueue
             try {
                 $this->processTransactions();
             } catch (\Exception $e) {
-                nlog("{$this->account->bank_integration_yodlee_account_id} - exited abnormally => " . $e->getMessage());
+                nlog("{$this->account->bank_integration_account_id} - exited abnormally => " . $e->getMessage());
                 return;
             }
 
@@ -91,7 +91,7 @@ class ProcessBankTransactionsYodlee implements ShouldQueue
     private function processTransactions()
     {
 
-        $yodlee = new Yodlee($this->account->bank_integration_yodlee_account_id);
+        $yodlee = new Yodlee($this->account->bank_integration_account_id);
 
         if (!$yodlee->getAccount($this->bank_integration->bank_account_id)) {
             $this->bank_integration->disabled_upstream = true;

--- a/app/Jobs/Ninja/BankTransactionSync.php
+++ b/app/Jobs/Ninja/BankTransactionSync.php
@@ -53,7 +53,7 @@ class BankTransactionSync implements ShouldQueue
 
             nlog("syncing transactions - yodlee");
 
-            Account::with('bank_integrations')->whereNotNull('bank_integration_yodlee_account_id')->cursor()->each(function ($account) {
+            Account::with('bank_integrations')->whereNotNull('bank_integration_account_id')->cursor()->each(function ($account) {
 
                 if ($account->isPaid() && $account->plan == 'enterprise') {
 

--- a/app/Models/Account.php
+++ b/app/Models/Account.php
@@ -80,7 +80,9 @@ class Account extends BaseModel
         'created_at' => 'timestamp',
         'deleted_at' => 'timestamp',
         'onboarding' => 'object',
-        'set_react_as_default_ap' => 'bool'
+        'set_react_as_default_ap' => 'bool',
+        'bank_integration_nordigen_secret_id' => 'encrypted',
+        'bank_integration_nordigen_secret_key' => 'encrypted',
     ];
 
     const PLAN_FREE = 'free';

--- a/database/migrations/2023_11_26_082959_add_bank_integration_id.php
+++ b/database/migrations/2023_11_26_082959_add_bank_integration_id.php
@@ -15,7 +15,7 @@ return new class extends Migration {
     public function up()
     {
         Schema::table('bank_integrations', function (Blueprint $table) {
-            $table->string('integration_type')->default(BankIntegration::INTEGRATION_TYPE_NONE);
+            $table->string('integration_type')->nullable();
         });
 
         // migrate old account to be used with yodlee
@@ -26,7 +26,6 @@ return new class extends Migration {
 
         // MAYBE migration of account->bank_account_id etc
         Schema::table('accounts', function (Blueprint $table) {
-            $table->renameColumn('bank_integration_account_id', 'bank_integration_yodlee_account_id');
             $table->string('bank_integration_nordigen_secret_id')->nullable();
             $table->string('bank_integration_nordigen_secret_key')->nullable();
         });


### PR DESCRIPTION
Just a couple of minor fixes here.

We cannot change the current column naming of bank_integration_account_id for a number of reasons.

Instead, we should just prefix the new nordigen columns so that we can differentiate.

Also, for security, i've set the two nordigen secreted as encrypted casts, this should not require any additional work

Lastly, I think we can remove the integration type none as it is not needed, i've updated the migration to allow that column to be nullable.

I've 